### PR TITLE
chore: add docker compose file for run backing services

### DIFF
--- a/Doppler.EasyNetQ.HosepipeWorker.sln
+++ b/Doppler.EasyNetQ.HosepipeWorker.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.doppler-ci = .doppler-ci
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		docker-compose.backing-services.yml = docker-compose.backing-services.yml
 		docker-compose.yml = docker-compose.yml
 		Dockerfile = Dockerfile
 		.config\dotnet-tools.json = .config\dotnet-tools.json

--- a/docker-compose.backing-services.yml
+++ b/docker-compose.backing-services.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  rabbitmq:
+    image: rabbitmq:management
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-guest}
+    ports:
+      - 5672:5672
+      - 15672:15672


### PR DESCRIPTION
Hosepipe require connect to a RabbitMQ instance that hold the queue with `Error` messages generated by the client _EasyNetQ_
This stack allow run a clean instances of the service to be used for debug and tests.