### PR TITLE
Allow indicate the password separate of connection string

### DIFF
--- a/Doppler.EasyNetQ.HosepipeWorker/BusStation.cs
+++ b/Doppler.EasyNetQ.HosepipeWorker/BusStation.cs
@@ -18,14 +18,21 @@ namespace Doppler.EasyNetQ.HosepipeWorker
 
             foreach (var connection in options.Value.Connections)
             {
-                var connectionConfiguration = new ConnectionStringParser().Parse(connection.ConnectionString);
-                if (!string.IsNullOrWhiteSpace(connection.Password))
+                try
                 {
-                    connectionConfiguration.Password = connection.Password;
-                }
-                var bus = RabbitHutch.CreateBus(connectionConfiguration, x => { });
+                    var connectionConfiguration = new ConnectionStringParser().Parse(connection.ConnectionString);
+                    if (!string.IsNullOrWhiteSpace(connection.Password))
+                    {
+                        connectionConfiguration.Password = connection.Password;
+                    }
+                    var bus = RabbitHutch.CreateBus(connectionConfiguration, x => { });
 
-                TryAddBus(connection.Name, bus);
+                    TryAddBus(connection.Name, bus);
+                }
+                catch (EasyNetQException ex)
+                {
+                    _logger.LogError(ex, "Can create connection bus for service {BusName}", connection.Name);
+                }
             }
         }
 

--- a/Doppler.EasyNetQ.HosepipeWorker/BusStation.cs
+++ b/Doppler.EasyNetQ.HosepipeWorker/BusStation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using EasyNetQ;
+using EasyNetQ.ConnectionString;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -17,7 +18,12 @@ namespace Doppler.EasyNetQ.HosepipeWorker
 
             foreach (var connection in options.Value.Connections)
             {
-                var bus = RabbitHutch.CreateBus(connection.ConnectionString, x => { });
+                var connectionConfiguration = new ConnectionStringParser().Parse(connection.ConnectionString);
+                if (!string.IsNullOrWhiteSpace(connection.Password))
+                {
+                    connectionConfiguration.Password = connection.Password;
+                }
+                var bus = RabbitHutch.CreateBus(connectionConfiguration, x => { });
 
                 TryAddBus(connection.Name, bus);
             }

--- a/Doppler.EasyNetQ.HosepipeWorker/HosepipeSettings.cs
+++ b/Doppler.EasyNetQ.HosepipeWorker/HosepipeSettings.cs
@@ -24,5 +24,10 @@ namespace Doppler.EasyNetQ.HosepipeWorker
     {
         public string Name { get; set; }
         public string ConnectionString { get; set; }
+        /// <summary>
+        /// The secret password of the user indicate in the <see cref="ConnectionString"/>
+        /// </summary>
+        /// <remarks>If ConnectionString has defined password parameter, will be replaced with this value if it is not empty.</remarks>
+        public string Password { get; set; }
     }
 }


### PR DESCRIPTION
This is useful for store the password as encrypted secret and keep the rest of the connection string as clear text.