### PR TITLE
[DD-1381] allow retry unsolved messages

### DIFF
--- a/Doppler.EasyNetQ.HosepipeWorker/BusStation.cs
+++ b/Doppler.EasyNetQ.HosepipeWorker/BusStation.cs
@@ -25,7 +25,11 @@ namespace Doppler.EasyNetQ.HosepipeWorker
                     {
                         connectionConfiguration.Password = connection.Value.SecretPassword;
                     }
-                    var bus = RabbitHutch.CreateBus(connectionConfiguration, x => { });
+                    var bus = RabbitHutch.CreateBus(connectionConfiguration, x =>
+                    {
+                        if (connection.Value.EnableLegacyTypeNaming)
+                            x.EnableLegacyTypeNaming();
+                    });
 
                     bus.Advanced.QueueDeclare(options.Value.ErrorQueueName);
                     bus.Advanced.QueueDeclare(options.Value.UnsolvedErrorQueueName);

--- a/Doppler.EasyNetQ.HosepipeWorker/HosepipeService.cs
+++ b/Doppler.EasyNetQ.HosepipeWorker/HosepipeService.cs
@@ -128,14 +128,7 @@ namespace Doppler.EasyNetQ.HosepipeWorker
                 {
                     _logger.LogWarning("Max retry reached");
 
-                    await _busStation.GetBus(service).Advanced.PublishAsync(
-                        exchange: Exchange.GetDefault(),
-                        routingKey: _hosepipeSettings.UnsolvedErrorQueueName,
-                        mandatory: true,
-                        messageProperties: error.BasicProperties,
-                        body: new JsonSerializer().MessageToBytes(typeof(Error), error));
-
-                    _logger.LogInformation("Error published to {QueueName}", _hosepipeSettings.UnsolvedErrorQueueName);
+                    await PublishErrorToUnsolvedQueue(service, error);
 
                     return;
                 }
@@ -154,14 +147,7 @@ namespace Doppler.EasyNetQ.HosepipeWorker
                 {
                     _logger.LogError(ex, "Unexpected problem publishing message to the original queue");
 
-                    await _busStation.GetBus(service).Advanced.PublishAsync(
-                        exchange: Exchange.GetDefault(),
-                        routingKey: _hosepipeSettings.UnsolvedErrorQueueName,
-                        mandatory: true,
-                        messageProperties: error.BasicProperties,
-                        body: new JsonSerializer().MessageToBytes(typeof(Error), error));
-
-                    _logger.LogInformation("Error published to {QueueName}", _hosepipeSettings.UnsolvedErrorQueueName);
+                    await PublishErrorToUnsolvedQueue(service, error);
                 }
                 catch (Exception republishErrorException)
                 {
@@ -171,6 +157,18 @@ namespace Doppler.EasyNetQ.HosepipeWorker
                         error);
                 }
             }
+        }
+
+        private async Task PublishErrorToUnsolvedQueue(string service, Error error)
+        {
+            await _busStation.GetBus(service).Advanced.PublishAsync(
+                exchange: Exchange.GetDefault(),
+                routingKey: _hosepipeSettings.UnsolvedErrorQueueName,
+                mandatory: true,
+                messageProperties: error.BasicProperties,
+                body: new JsonSerializer().MessageToBytes(typeof(Error), error));
+
+            _logger.LogInformation("Error published to {QueueName}", _hosepipeSettings.UnsolvedErrorQueueName);
         }
     }
 }

--- a/Doppler.EasyNetQ.HosepipeWorker/HosepipeService.cs
+++ b/Doppler.EasyNetQ.HosepipeWorker/HosepipeService.cs
@@ -161,6 +161,8 @@ namespace Doppler.EasyNetQ.HosepipeWorker
 
         private async Task PublishErrorToUnsolvedQueue(string service, Error error)
         {
+            error.BasicProperties.Headers[_hosepipeSettings.RetryCountHeader] = 0;
+
             await _busStation.GetBus(service).Advanced.PublishAsync(
                 exchange: Exchange.GetDefault(),
                 routingKey: _hosepipeSettings.UnsolvedErrorQueueName,

--- a/Doppler.EasyNetQ.HosepipeWorker/HosepipeSettings.cs
+++ b/Doppler.EasyNetQ.HosepipeWorker/HosepipeSettings.cs
@@ -28,5 +28,7 @@ namespace Doppler.EasyNetQ.HosepipeWorker
         /// </summary>
         /// <remarks>If ConnectionString has defined password parameter, will be replaced with this value if it is not empty.</remarks>
         public string SecretPassword { get; set; }
+
+        public bool EnableLegacyTypeNaming { get; set; }
     }
 }


### PR DESCRIPTION
This PR is to reset the retry counter when publishing the message to the unsolved queue, this allows moving the messages manually from the unsolved queue to the default error queue to be reprocessed.

The handle of the default error queue retry the message 5 times