### PR TITLE
chore: rollback version and enable rollForward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.201"
+    "version": "8.0.101",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This is because codeql github action and fedora linux are not ready for the latest version